### PR TITLE
Fix CSS modules selector error

### DIFF
--- a/components/main-header.module.css
+++ b/components/main-header.module.css
@@ -12,7 +12,7 @@
   filter: drop-shadow(0 0 2px #f4c33d);
 }
 
-nav ul {
+.header nav ul {
   display: flex;
   list-style: none;
   margin: 0;
@@ -20,12 +20,12 @@ nav ul {
   gap: 1rem;
 }
 
-nav a {
+.header nav a {
   color: #f4c33d;
   text-decoration: none;
 }
 
-nav a:hover,
-nav a:active {
+.header nav a:hover,
+.header nav a:active {
   color: #bd3df4;
 }


### PR DESCRIPTION
## Summary
- fix compile error by using a local class in the selectors

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848f1d576208328a1ef217ce97f61ca