### PR TITLE
Fix server/client boundary for AntD table

### DIFF
--- a/app/users/page.js
+++ b/app/users/page.js
@@ -1,33 +1,14 @@
-import { Table } from 'antd';
-import Link from 'next/link';
+import UsersTable from '@/components/users-table';
 
 export default async function UsersPage() {
   const response = await fetch('https://jsonplaceholder.typicode.com/users');
   const users = await response.json();
 
-  const columns = [
-    {
-      title: 'Name',
-      dataIndex: 'name',
-      key: 'name',
-      render: (text, record) => <Link href={`/users/${record.id}`}>{text}</Link>,
-    },
-    {
-      title: 'Email',
-      dataIndex: 'email',
-      key: 'email',
-    },
-    {
-      title: 'City',
-      dataIndex: ['address', 'city'],
-      key: 'city',
-    },
-  ];
 
   return (
     <main>
       <h1>Users</h1>
-      <Table dataSource={users} columns={columns} rowKey="id" pagination={false} />
+      <UsersTable users={users} />
     </main>
   );
 }

--- a/components/users-table.js
+++ b/components/users-table.js
@@ -1,0 +1,27 @@
+'use client';
+
+import { Table } from 'antd';
+import Link from 'next/link';
+
+export default function UsersTable({ users }) {
+  const columns = [
+    {
+      title: 'Name',
+      dataIndex: 'name',
+      key: 'name',
+      render: (text, record) => <Link href={`/users/${record.id}`}>{text}</Link>,
+    },
+    {
+      title: 'Email',
+      dataIndex: 'email',
+      key: 'email',
+    },
+    {
+      title: 'City',
+      dataIndex: ['address', 'city'],
+      key: 'city',
+    },
+  ];
+
+  return <Table dataSource={users} columns={columns} rowKey="id" pagination={false} />;
+}


### PR DESCRIPTION
## Summary
- create a `UsersTable` client component for displaying users
- use the new component in the `/users` page to avoid passing functions from the server

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848f3f5cffc8328853b3eef37e37bda