### PR TITLE
Add posts listing feature

### DIFF
--- a/app/posts/[id]/page.js
+++ b/app/posts/[id]/page.js
@@ -1,0 +1,16 @@
+import Link from 'next/link';
+
+export default async function PostDetailPage({ params }) {
+  const response = await fetch(`https://jsonplaceholder.typicode.com/posts/${params.id}`);
+  const post = await response.json();
+
+  return (
+    <main>
+      <h1>{post.title}</h1>
+      <p>{post.body}</p>
+      <p>
+        <Link href="/posts">Back to Posts</Link>
+      </p>
+    </main>
+  );
+}

--- a/app/posts/page.js
+++ b/app/posts/page.js
@@ -1,0 +1,13 @@
+import PostsTable from '@/components/posts-table';
+
+export default async function PostsPage() {
+  const response = await fetch('https://jsonplaceholder.typicode.com/posts');
+  const posts = await response.json();
+
+  return (
+    <main>
+      <h1>Posts</h1>
+      <PostsTable posts={posts} />
+    </main>
+  );
+}

--- a/components/main-header.js
+++ b/components/main-header.js
@@ -17,6 +17,9 @@ export default function MainHeader() {
           <li>
             <Link href="/users">Users</Link>
           </li>
+          <li>
+            <Link href="/posts">Posts</Link>
+          </li>
         </ul>
       </nav>
     </header>

--- a/components/posts-table.js
+++ b/components/posts-table.js
@@ -1,0 +1,22 @@
+'use client';
+
+import { Table } from 'antd';
+import Link from 'next/link';
+
+export default function PostsTable({ posts }) {
+  const columns = [
+    {
+      title: 'Title',
+      dataIndex: 'title',
+      key: 'title',
+      render: (text, record) => <Link href={`/posts/${record.id}`}>{text}</Link>,
+    },
+    {
+      title: 'Body',
+      dataIndex: 'body',
+      key: 'body',
+    },
+  ];
+
+  return <Table dataSource={posts} columns={columns} rowKey="id" pagination={false} />;
+}


### PR DESCRIPTION
## Summary
- add posts link in main header
- show posts with AntD table
- list posts at `/posts`
- show individual post details

## Testing
- `npm run lint` *(fails: `next` not found)*

------