### PR TITLE
Add photos pages feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ The application provides basic pages for the following resources:
 - **Comments** – shows comments
 - **Todos** – shows todo items
 - **Albums** – displays albums
+- **Photos** – displays photos with thumbnails
 
 Each page fetches the corresponding data on the server and renders a table component in the browser.
 

--- a/app/photos/[id]/page.js
+++ b/app/photos/[id]/page.js
@@ -1,0 +1,17 @@
+import Link from 'next/link';
+
+export default async function PhotoDetailPage({ params }) {
+  const response = await fetch(`https://jsonplaceholder.typicode.com/photos/${params.id}`);
+  const photo = await response.json();
+
+  return (
+    <main>
+      <h1>{photo.title}</h1>
+      <img src={photo.url} alt={photo.title} />
+      <p>Album ID: {photo.albumId}</p>
+      <p>
+        <Link href="/photos">Back to Photos</Link>
+      </p>
+    </main>
+  );
+}

--- a/app/photos/page.js
+++ b/app/photos/page.js
@@ -1,0 +1,13 @@
+import PhotosTable from '@/components/photos-table';
+
+export default async function PhotosPage() {
+  const response = await fetch('https://jsonplaceholder.typicode.com/photos');
+  const photos = await response.json();
+
+  return (
+    <main>
+      <h1>Photos</h1>
+      <PhotosTable photos={photos} />
+    </main>
+  );
+}

--- a/components/main-header.js
+++ b/components/main-header.js
@@ -29,6 +29,9 @@ export default function MainHeader() {
           <li>
             <Link href="/albums">Albums</Link>
           </li>
+          <li>
+            <Link href="/photos">Photos</Link>
+          </li>
         </ul>
       </nav>
     </header>

--- a/components/photos-table.js
+++ b/components/photos-table.js
@@ -1,0 +1,28 @@
+'use client';
+
+import EditableTable from './editable-table';
+import Link from 'next/link';
+
+export default function PhotosTable({ photos }) {
+  const columns = [
+    {
+      title: 'Title',
+      dataIndex: 'title',
+      key: 'title',
+      render: (text, record) => <Link href={`/photos/${record.id}`}>{text}</Link>,
+    },
+    {
+      title: 'Album ID',
+      dataIndex: 'albumId',
+      key: 'albumId',
+    },
+    {
+      title: 'Thumbnail',
+      dataIndex: 'thumbnailUrl',
+      key: 'thumbnailUrl',
+      render: url => <img src={url} alt="thumb" style={{ width: 50 }} />,
+    },
+  ];
+
+  return <EditableTable data={photos} columns={columns} />;
+}


### PR DESCRIPTION
## Summary
- add photos table component
- add photos pages and detail pages
- link to photos in the main header navigation
- document the photos page in README

## Testing
- `npm run lint` *(fails: `next` not found)*

------
