### PR TITLE
Add editable tables and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# Next.js Starting Project
+
+This project is a small Next.js application using Ant Design tables to display data fetched from [jsonplaceholder](https://jsonplaceholder.typicode.com/). The tables now support in–place editing of their contents.
+
+## Development
+
+Install dependencies and start the development server:
+
+```bash
+npm install
+npm run dev
+```
+
+Open `http://localhost:3000` in your browser to view the app.
+
+## Features
+
+- Lists of users, posts, todos, comments and albums
+- Editable table rows for all lists
+
+## Build
+
+To create a production build:
+
+```bash
+npm run build
+npm start
+```

--- a/app/users/page.js
+++ b/app/users/page.js
@@ -2,8 +2,8 @@ import UsersTable from '@/components/users-table';
 
 export default async function UsersPage() {
   const response = await fetch('https://jsonplaceholder.typicode.com/users');
-  const users = await response.json();
-
+  const usersData = await response.json();
+  const users = usersData.map((user) => ({ ...user, city: user.address?.city }));
 
   return (
     <main>
@@ -12,4 +12,3 @@ export default async function UsersPage() {
     </main>
   );
 }
-

--- a/components/albums-table.js
+++ b/components/albums-table.js
@@ -1,7 +1,6 @@
 'use client';
 
-import { Table } from 'antd';
-import Link from 'next/link';
+import EditableTable from './editable-table';
 
 export default function AlbumsTable({ albums }) {
   const columns = [
@@ -9,14 +8,16 @@ export default function AlbumsTable({ albums }) {
       title: 'Title',
       dataIndex: 'title',
       key: 'title',
-      render: (text, record) => <Link href={`/albums/${record.id}`}>{text}</Link>,
+      editable: true,
+      renderLink: (record) => `/albums/${record.id}`,
     },
     {
       title: 'User ID',
       dataIndex: 'userId',
       key: 'userId',
+      editable: true,
     },
   ];
 
-  return <Table dataSource={albums} columns={columns} rowKey="id" pagination={false} />;
+  return <EditableTable data={albums} columns={columns} rowKey="id" />;
 }

--- a/components/comments-table.js
+++ b/components/comments-table.js
@@ -1,7 +1,6 @@
 'use client';
 
-import { Table } from 'antd';
-import Link from 'next/link';
+import EditableTable from './editable-table';
 
 export default function CommentsTable({ comments }) {
   const columns = [
@@ -9,19 +8,22 @@ export default function CommentsTable({ comments }) {
       title: 'Name',
       dataIndex: 'name',
       key: 'name',
-      render: (text, record) => <Link href={`/comments/${record.id}`}>{text}</Link>,
+      editable: true,
+      renderLink: (record) => `/comments/${record.id}`,
     },
     {
       title: 'Email',
       dataIndex: 'email',
       key: 'email',
+      editable: true,
     },
     {
       title: 'Body',
       dataIndex: 'body',
       key: 'body',
+      editable: true,
     },
   ];
 
-  return <Table dataSource={comments} columns={columns} rowKey="id" pagination={false} />;
+  return <EditableTable data={comments} columns={columns} rowKey="id" />;
 }

--- a/components/editable-table.js
+++ b/components/editable-table.js
@@ -1,0 +1,92 @@
+'use client';
+
+import { useState } from 'react';
+import { Table, Input, Button, Checkbox } from 'antd';
+import Link from 'next/link';
+
+export default function EditableTable({ data, columns, rowKey }) {
+  const [tableData, setTableData] = useState(data);
+  const [editingId, setEditingId] = useState(null);
+  const [formData, setFormData] = useState({});
+
+  const edit = (record) => {
+    setEditingId(record[rowKey]);
+    setFormData(record);
+  };
+
+  const cancel = () => {
+    setEditingId(null);
+    setFormData({});
+  };
+
+  const save = () => {
+    setTableData((prev) =>
+      prev.map((row) => (row[rowKey] === editingId ? formData : row))
+    );
+    cancel();
+  };
+
+  const handleChange = (key, value) => {
+    setFormData((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const renderCell = (col, record) => {
+    const isEditing = record[rowKey] === editingId;
+    const value = formData[col.dataIndex];
+    if (isEditing && col.editable !== false) {
+      if (col.dataIndex === 'completed') {
+        return (
+          <Checkbox
+            checked={value}
+            onChange={(e) => handleChange(col.dataIndex, e.target.checked)}
+          />
+        );
+      }
+      return (
+        <Input
+          value={value}
+          onChange={(e) => handleChange(col.dataIndex, e.target.value)}
+        />
+      );
+    }
+
+    if (col.renderLink) {
+      const href =
+        typeof col.renderLink === 'function'
+          ? col.renderLink(record)
+          : col.renderLink;
+      return <Link href={href}>{record[col.dataIndex]}</Link>;
+    }
+
+    return record[col.dataIndex];
+  };
+
+  const cols = columns.map((col) => ({
+    ...col,
+    render: (text, record) => renderCell(col, record),
+  }));
+
+  cols.push({
+    title: 'Actions',
+    key: 'actions',
+    render: (_, record) => {
+      const editable = record[rowKey] === editingId;
+      return editable ? (
+        <>
+          <Button type="link" onClick={save}>
+            Save
+          </Button>
+          <Button type="link" onClick={cancel}>
+            Cancel
+          </Button>
+        </>
+      ) : (
+        <Button type="link" onClick={() => edit(record)}>
+          Edit
+        </Button>
+      );
+    },
+  });
+
+  return <Table dataSource={tableData} columns={cols} rowKey={rowKey} pagination={false} />;
+}

--- a/components/posts-table.js
+++ b/components/posts-table.js
@@ -1,7 +1,6 @@
 'use client';
 
-import { Table } from 'antd';
-import Link from 'next/link';
+import EditableTable from './editable-table';
 
 export default function PostsTable({ posts }) {
   const columns = [
@@ -9,14 +8,16 @@ export default function PostsTable({ posts }) {
       title: 'Title',
       dataIndex: 'title',
       key: 'title',
-      render: (text, record) => <Link href={`/posts/${record.id}`}>{text}</Link>,
+      editable: true,
+      renderLink: (record) => `/posts/${record.id}`,
     },
     {
       title: 'Body',
       dataIndex: 'body',
       key: 'body',
+      editable: true,
     },
   ];
 
-  return <Table dataSource={posts} columns={columns} rowKey="id" pagination={false} />;
+  return <EditableTable data={posts} columns={columns} rowKey="id" />;
 }

--- a/components/todos-table.js
+++ b/components/todos-table.js
@@ -1,7 +1,6 @@
 'use client';
 
-import { Table } from 'antd';
-import Link from 'next/link';
+import EditableTable from './editable-table';
 
 export default function TodosTable({ todos }) {
   const columns = [
@@ -9,15 +8,16 @@ export default function TodosTable({ todos }) {
       title: 'Title',
       dataIndex: 'title',
       key: 'title',
-      render: (text, record) => <Link href={`/todos/${record.id}`}>{text}</Link>,
+      editable: true,
+      renderLink: (record) => `/todos/${record.id}`,
     },
     {
       title: 'Completed',
       dataIndex: 'completed',
       key: 'completed',
-      render: completed => (completed ? 'Yes' : 'No'),
+      editable: true,
     },
   ];
 
-  return <Table dataSource={todos} columns={columns} rowKey="id" pagination={false} />;
+  return <EditableTable data={todos} columns={columns} rowKey="id" />;
 }

--- a/components/users-table.js
+++ b/components/users-table.js
@@ -1,7 +1,6 @@
 'use client';
 
-import { Table } from 'antd';
-import Link from 'next/link';
+import EditableTable from './editable-table';
 
 export default function UsersTable({ users }) {
   const columns = [
@@ -9,19 +8,22 @@ export default function UsersTable({ users }) {
       title: 'Name',
       dataIndex: 'name',
       key: 'name',
-      render: (text, record) => <Link href={`/users/${record.id}`}>{text}</Link>,
+      editable: true,
+      renderLink: (record) => `/users/${record.id}`,
     },
     {
       title: 'Email',
       dataIndex: 'email',
       key: 'email',
+      editable: true,
     },
     {
       title: 'City',
-      dataIndex: ['address', 'city'],
+      dataIndex: 'city',
       key: 'city',
+      editable: true,
     },
   ];
 
-  return <Table dataSource={users} columns={columns} rowKey="id" pagination={false} />;
+  return <EditableTable data={users} columns={columns} rowKey="id" />;
 }


### PR DESCRIPTION
## Summary
- add README with instructions
- add generic EditableTable component
- update resource tables to support editing
- map user city data for editing

## Testing
- `npm run lint` *(fails: `next` not found)*

------