### PR TITLE
Fix completed column display

### DIFF
--- a/components/editable-table.js
+++ b/components/editable-table.js
@@ -58,6 +58,10 @@ export default function EditableTable({ data, columns, rowKey }) {
       return <Link href={href}>{record[col.dataIndex]}</Link>;
     }
 
+    if (typeof record[col.dataIndex] === 'boolean') {
+      return record[col.dataIndex] ? 'Yes' : 'No';
+    }
+
     return record[col.dataIndex];
   };
 


### PR DESCRIPTION
## Summary
- handle boolean values in EditableTable so `completed` displays correctly

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: `next: not found`)*

------