### PR TITLE
Add local storage persistence for editable tables

### DIFF
--- a/components/albums-table.js
+++ b/components/albums-table.js
@@ -19,5 +19,12 @@ export default function AlbumsTable({ albums }) {
     },
   ];
 
-  return <EditableTable data={albums} columns={columns} rowKey="id" />;
+  return (
+    <EditableTable
+      data={albums}
+      columns={columns}
+      rowKey="id"
+      storageKey="albums"
+    />
+  );
 }

--- a/components/comments-table.js
+++ b/components/comments-table.js
@@ -25,5 +25,12 @@ export default function CommentsTable({ comments }) {
     },
   ];
 
-  return <EditableTable data={comments} columns={columns} rowKey="id" />;
+  return (
+    <EditableTable
+      data={comments}
+      columns={columns}
+      rowKey="id"
+      storageKey="comments"
+    />
+  );
 }

--- a/components/editable-table.js
+++ b/components/editable-table.js
@@ -1,13 +1,28 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Table, Input, Button, Checkbox } from 'antd';
 import Link from 'next/link';
 
-export default function EditableTable({ data, columns, rowKey }) {
+export default function EditableTable({ data, columns, rowKey, storageKey }) {
   const [tableData, setTableData] = useState(data);
   const [editingId, setEditingId] = useState(null);
   const [formData, setFormData] = useState({});
+
+  useEffect(() => {
+    if (!storageKey || typeof window === 'undefined') return;
+    const stored = localStorage.getItem(storageKey);
+    if (stored) {
+      try {
+        setTableData(JSON.parse(stored));
+      } catch {
+        localStorage.removeItem(storageKey);
+        localStorage.setItem(storageKey, JSON.stringify(data));
+      }
+    } else {
+      localStorage.setItem(storageKey, JSON.stringify(data));
+    }
+  }, [data, storageKey]);
 
   const edit = (record) => {
     setEditingId(record[rowKey]);
@@ -20,9 +35,15 @@ export default function EditableTable({ data, columns, rowKey }) {
   };
 
   const save = () => {
-    setTableData((prev) =>
-      prev.map((row) => (row[rowKey] === editingId ? formData : row))
-    );
+    setTableData((prev) => {
+      const updated = prev.map((row) =>
+        row[rowKey] === editingId ? formData : row
+      );
+      if (storageKey && typeof window !== 'undefined') {
+        localStorage.setItem(storageKey, JSON.stringify(updated));
+      }
+      return updated;
+    });
     cancel();
   };
 

--- a/components/posts-table.js
+++ b/components/posts-table.js
@@ -19,5 +19,12 @@ export default function PostsTable({ posts }) {
     },
   ];
 
-  return <EditableTable data={posts} columns={columns} rowKey="id" />;
+  return (
+    <EditableTable
+      data={posts}
+      columns={columns}
+      rowKey="id"
+      storageKey="posts"
+    />
+  );
 }

--- a/components/todos-table.js
+++ b/components/todos-table.js
@@ -19,5 +19,12 @@ export default function TodosTable({ todos }) {
     },
   ];
 
-  return <EditableTable data={todos} columns={columns} rowKey="id" />;
+  return (
+    <EditableTable
+      data={todos}
+      columns={columns}
+      rowKey="id"
+      storageKey="todos"
+    />
+  );
 }

--- a/components/users-table.js
+++ b/components/users-table.js
@@ -25,5 +25,12 @@ export default function UsersTable({ users }) {
     },
   ];
 
-  return <EditableTable data={users} columns={columns} rowKey="id" />;
+  return (
+    <EditableTable
+      data={users}
+      columns={columns}
+      rowKey="id"
+      storageKey="users"
+    />
+  );
 }


### PR DESCRIPTION
## Summary
- persist edited table data using `localStorage`
- give each table component a unique `storageKey`

## Testing
- `npm run lint` *(fails: `next` not found)*

------