### PR TITLE
Restrict editing to logged-in users

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Open `http://localhost:3000` in your browser to view the app.
 ## Features
 
 - Lists of users, posts, todos, comments and albums
-- Editable table rows for all lists
+- Editable table rows for all lists (login required)
 - Search tables by any field
 - Editable tags for each row
 - User login with sign out option


### PR DESCRIPTION
## Summary
- make editable table actions conditional on user login
- watch user change events to keep login state current
- document that editing requires login

## Testing
- `npm run lint` *(fails: `next` not found)*
