### PR TITLE
Fix key warnings in table actions

### DIFF
--- a/components/editable-table.js
+++ b/components/editable-table.js
@@ -117,10 +117,10 @@ export default function EditableTable({ data, columns, rowKey, storageKey }) {
         const editable = record[rowKey] === editingId;
         return editable ? (
           <>
-            <Button type="link" onClick={save}>
+            <Button key="save" type="link" onClick={save}>
               Save
             </Button>
-            <Button type="link" onClick={cancel}>
+            <Button key="cancel" type="link" onClick={cancel}>
               Cancel
             </Button>
           </>


### PR DESCRIPTION
## Summary
- fix React key warnings by adding keys to action buttons

## Testing
- `npm run lint` *(fails: next not found)*