### PR TITLE
Add antd language dropdown

### DIFF
--- a/components/language-dropdown.js
+++ b/components/language-dropdown.js
@@ -1,0 +1,34 @@
+'use client'
+
+import { useState, useEffect } from 'react';
+import { Dropdown, Button } from 'antd';
+
+export default function LanguageDropdown() {
+  const [language, setLanguage] = useState('en');
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const stored = localStorage.getItem('language');
+    if (stored) {
+      setLanguage(stored);
+    }
+  }, []);
+
+  const handleMenuClick = ({ key }) => {
+    setLanguage(key);
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('language', key);
+    }
+  };
+
+  const items = [
+    { label: 'English', key: 'en' },
+    { label: 'French', key: 'fr' },
+  ];
+
+  return (
+    <Dropdown menu={{ items, onClick: handleMenuClick }} placement="bottomRight">
+      <Button>{language === 'en' ? 'English' : 'French'}</Button>
+    </Dropdown>
+  );
+}

--- a/components/main-header.js
+++ b/components/main-header.js
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import classes from './main-header.module.css';
+import LanguageDropdown from './language-dropdown';
 
 export default function MainHeader() {
   const [username, setUsername] = useState('');
@@ -84,6 +85,9 @@ export default function MainHeader() {
               </li>
             </>
           )}
+          <li>
+            <LanguageDropdown />
+          </li>
         </ul>
       </nav>
     </header>


### PR DESCRIPTION
## Summary
- enable language selection with a new `LanguageDropdown` component
- integrate the dropdown in `MainHeader`

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npx next lint` *(fails: 403 Forbidden to fetch packages)*