### PR TITLE
Fix supabase link in header

### DIFF
--- a/app/supabase/page.js
+++ b/app/supabase/page.js
@@ -2,15 +2,15 @@ import SupabaseTable from '@/components/supabase-table';
 import supabase from '@/lib/supabase';
 
 export const metadata = {
-  title: 'Test Address',
+  title: 'Supabase Table',
 };
 
-export default async function TestAddressPage() {
+export default async function SupabasePage() {
   const { data } = await supabase.from('Test_Address').select('*');
 
   return (
     <main>
-      <h1>Test Address</h1>
+      <h1>Supabase Table</h1>
       <SupabaseTable data={data || []} />
     </main>
   );

--- a/components/main-header.js
+++ b/components/main-header.js
@@ -108,7 +108,7 @@ export default function MainHeader() {
             <Link href="/albums">{t.albums}</Link>
           </li>
           <li>
-            <Link href="/test-address">{t.supabase}</Link>
+            <Link href="/supabase">{t.supabase}</Link>
           </li>
           {username ? (
             <>


### PR DESCRIPTION
## Summary
- rename `test-address` page to `supabase`
- update header navigation to link to `/supabase`
- update Supabase page title and heading